### PR TITLE
Initialization.cpp: Fix clock for C3 board

### DIFF
--- a/src/Initialization.cpp
+++ b/src/Initialization.cpp
@@ -7,8 +7,8 @@
 // Any code written here will be called before main() is entered.
 void __attribute__((constructor)) Initialize()
 {
-  // Configure system clock for 98.304 MHz from a 12.288 MHz xtal
-  sys_clock_init(crys_12_288_MHz, _24_576_MHz);
+  // Configure system clock for 98.304 MHz from a 24.576 MHz xtal
+  sys_clock_init(crys_24_576_MHz, _98_304_MHz);
 
   // Configure a pull-up on pin PG0
   // This pull-up prevents an XPD write from stalling execution if


### PR DESCRIPTION
The crystal oscillator on the C3 board is 24.576 MHz, not 12.288 MHz. This also changes the system frequency to 98.304 MHz.